### PR TITLE
[sc-106495] cleartext password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 0.1.7](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.1.7) - Feature release - 2023-06-21
+
+- Feature: add secure personal preset
+
 ## [Version 0.1.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.1.6) - Feature release - 2022-11-14
 
 - Feature: add a project selector

--- a/parameter-sets/secure-connection/parameter-set.json
+++ b/parameter-sets/secure-connection/parameter-set.json
@@ -1,0 +1,51 @@
+{
+    "meta" : {
+        "label": "Tableau Server Secure Preset",
+        "description": "Tableau Server Secure Preset",
+        "icon": "icon-tableau"
+    },
+    "defaultDefinableInline": false,
+    "defaultDefinableAtProjectLevel": false,
+
+    "pluginParams": [],
+
+    "params": [
+        {
+            "name": "server_url",
+            "label":"URL",
+            "type": "STRING",
+            "mandatory": true,
+            "description": "URL of your Tableau server without subpaths. \nFor local Tableau servers, an example would be: https://www.MY_SERVER.com. For Tableau Online, \nan example would be: https://10ax.online.tableau.com/."
+        },
+        {
+            "name": "site_id",
+            "label":"Site ID",
+            "type": "STRING",
+            "description":"The site_id is the subpath of your full site URL."
+        },
+        {
+            "name": "ignore_ssl",
+            "label" : "Ignore SSL",
+            "type": "BOOLEAN",
+            "mandatory": false,
+            "description": "(not recommended)",
+            "defaultValue": false
+        },
+        {
+            "name": "ssl_cert_path",
+            "label": "SSL certificate",
+            "type": "STRING",
+            "description": "(optional) Full path to your tableau SSL certificate",
+            "mandatory": false,
+            "visibilityCondition": "model.ignore_ssl == false"
+        },
+        {
+            "name": "tableau_secure_basic",
+            "type": "CREDENTIAL_REQUEST",
+            "label": "Tableau basic login",
+            "credentialRequestSettings": {
+                "type": "BASIC"
+            }
+        }
+    ]
+}

--- a/parameter-sets/tableau-personal-connection/parameter-set.json
+++ b/parameter-sets/tableau-personal-connection/parameter-set.json
@@ -1,7 +1,7 @@
 {
     "meta" : {
-        "label": "Tableau Server Secure Preset",
-        "description": "Tableau Server Secure Preset",
+        "label": "Tableau Server Personal Preset",
+        "description": "Tableau Server Personal Preset",
         "icon": "icon-tableau"
     },
     "defaultDefinableInline": false,
@@ -40,7 +40,7 @@
             "visibilityCondition": "model.ignore_ssl == false"
         },
         {
-            "name": "tableau_secure_basic",
+            "name": "tableau_personal_basic",
             "type": "CREDENTIAL_REQUEST",
             "label": "Tableau basic login",
             "credentialRequestSettings": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "tableau-hyper-export",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "meta": {
         "label": "Tableau Hyper format",
         "description": "Export datasets to Tableau .hyper format.",

--- a/python-exporters/tableau-hyper_upload/exporter.json
+++ b/python-exporters/tableau-hyper_upload/exporter.json
@@ -23,7 +23,7 @@
             "type": "SELECT",
             "selectChoices": [
                 {
-                    "value": "basic-oauth",
+                    "value": "basic-preset",
                     "label": "Personal preset"
                 },
                 {
@@ -49,7 +49,7 @@
             "label": "Tableau Server Personal Preset",
             "type": "PRESET",
             "parameterSetId": "tableau-personal-connection",
-            "visibilityCondition": "model.auth_type == 'basic-oauth'"
+            "visibilityCondition": "model.auth_type == 'basic-preset'"
         },
         {
             "name": "tableau_server_connection",

--- a/python-exporters/tableau-hyper_upload/exporter.json
+++ b/python-exporters/tableau-hyper_upload/exporter.json
@@ -56,28 +56,28 @@
             "label": "Tableau Server Preset",
             "type": "PRESET",
             "parameterSetId": "tableau-server-connection",
-            "visibilityCondition": "model.auth_type == 'legacy-preset'"
+            "visibilityCondition": "model.auth_type == 'legacy-preset' || (model.auth_type == null && model.usePreset == true)"
         },
         {
             "name": "server_url",
             "label":"URL",
             "type": "STRING",
             "mandatory": false,
-            "visibilityCondition": "model.auth_type == 'legacy-login'"
+            "visibilityCondition": "model.auth_type == 'legacy-login' || (model.auth_type == null && model.usePreset == false && model.server_url != null)"
         },
         {
             "name": "username",
             "label":"Username",
             "type": "STRING",
             "mandatory": false,
-            "visibilityCondition": "model.auth_type == 'legacy-login'"
+            "visibilityCondition": "model.auth_type == 'legacy-login' || (model.auth_type == null && model.usePreset == false && model.server_url != null)"
         },
         {
             "name": "password",
             "label":"Password",
             "type": "PASSWORD",
             "mandatory": false,
-            "visibilityCondition": "model.auth_type == 'legacy-login'"
+            "visibilityCondition": "model.auth_type == 'legacy-login' || (model.auth_type == null && model.usePreset == false && model.server_url != null)"
         },
         {
             "name": "ignore_ssl",
@@ -86,7 +86,7 @@
             "mandatory": false,
             "description": "Ignore SSL",
             "defaultValue": false,
-            "visibilityCondition": "model.auth_type == 'legacy-login'"
+            "visibilityCondition": "model.auth_type == 'legacy-login' || (model.auth_type == null && model.server_url != null)"
         },
         {
             "name": "ssl_cert_path",
@@ -94,7 +94,7 @@
             "type": "STRING",
             "description": "(optional) Full path to your tableau SSL certificate",
             "mandatory": false,
-            "visibilityCondition": "(model.auth_type == 'legacy-login') && model.ignore_ssl == false"
+            "visibilityCondition": "(model.auth_type == 'legacy-login' || (model.auth_type == null && model.server_url != null)) && model.ignore_ssl == false"
         },
         {
             "label":"Destination",
@@ -138,7 +138,7 @@
             "type": "STRING",
             "description": "The site_id is the subpath of your full site URL. (See the README.md for details)",
             "mandatory": false,
-            "visibilityCondition": "model.auth_type == 'legacy-login'"
+            "visibilityCondition": "model.auth_type == 'legacy-login' || model.auth_type == null"
         }
     ]
 }

--- a/python-exporters/tableau-hyper_upload/exporter.json
+++ b/python-exporters/tableau-hyper_upload/exporter.json
@@ -18,39 +18,66 @@
             "type": "SEPARATOR"
         },
         {
+            "name": "auth_type",
+            "label": "Authentication type",
+            "type": "SELECT",
+            "selectChoices": [
+                {
+                    "value": "basic-oauth",
+                    "label": "Secure preset"
+                },
+                {
+                    "value": "legacy-preset",
+                    "label": "Preset (legacy)"
+                },
+                {
+                    "value": "legacy-login",
+                    "label": "User name / password (legacy)"
+                }
+            ]
+        },
+        {
             "name": "usePreset",
             "label" : "Use preset",
             "type": "BOOLEAN",
             "mandatory": false,
-            "description":"Get the Tableau Server connection parameters from a shared configuration in DSS"
+            "description":"Get the Tableau Server connection parameters from a shared configuration in DSS. Legacy: we just keep it to let existing flow working.",
+            "visibilityCondition": false
+        },
+        {
+            "name": "tableau_server_secure_connection",
+            "label": "Tableau Server Secure Preset",
+            "type": "PRESET",
+            "parameterSetId": "secure-connection",
+            "visibilityCondition": "model.auth_type == 'basic-oauth'"
         },
         {
             "name": "tableau_server_connection",
             "label": "Tableau Server Preset",
             "type": "PRESET",
             "parameterSetId": "tableau-server-connection",
-            "visibilityCondition": "model.usePreset == true"
+            "visibilityCondition": "model.auth_type == 'legacy-preset'"
         },
         {
             "name": "server_url",
             "label":"URL",
             "type": "STRING",
             "mandatory": false,
-            "visibilityCondition": "model.usePreset == false || model.tableau_server_connection.mode == 'NONE'"
+            "visibilityCondition": "model.auth_type == 'legacy-login'"
         },
         {
             "name": "username",
             "label":"Username",
             "type": "STRING",
             "mandatory": false,
-            "visibilityCondition": "model.usePreset == false || model.tableau_server_connection.mode == 'NONE'"
+            "visibilityCondition": "model.auth_type == 'legacy-login'"
         },
         {
             "name": "password",
             "label":"Password",
             "type": "PASSWORD",
             "mandatory": false,
-            "visibilityCondition": "model.usePreset == false || model.tableau_server_connection.mode == 'NONE'"
+            "visibilityCondition": "model.auth_type == 'legacy-login'"
         },
         {
             "name": "ignore_ssl",
@@ -59,7 +86,7 @@
             "mandatory": false,
             "description": "Ignore SSL",
             "defaultValue": false,
-            "visibilityCondition": "model.usePreset == false || model.tableau_server_connection.mode == 'NONE'"
+            "visibilityCondition": "model.auth_type == 'legacy-login'"
         },
         {
             "name": "ssl_cert_path",
@@ -67,7 +94,7 @@
             "type": "STRING",
             "description": "(optional) Full path to your tableau SSL certificate",
             "mandatory": false,
-            "visibilityCondition": "(model.usePreset == false || model.tableau_server_connection.mode == 'NONE') && model.ignore_ssl == false"
+            "visibilityCondition": "(model.auth_type == 'legacy-login') && model.ignore_ssl == false"
         },
         {
             "label":"Destination",
@@ -111,7 +138,7 @@
             "type": "STRING",
             "description": "The site_id is the subpath of your full site URL. (See the README.md for details)",
             "mandatory": false,
-            "visibilityCondition": "model.usePreset == false || model.tableau_server_connection.mode == 'NONE'"
+            "visibilityCondition": "model.auth_type == 'legacy-login'"
         }
     ]
 }

--- a/python-exporters/tableau-hyper_upload/exporter.json
+++ b/python-exporters/tableau-hyper_upload/exporter.json
@@ -24,7 +24,7 @@
             "selectChoices": [
                 {
                     "value": "basic-oauth",
-                    "label": "Secure preset"
+                    "label": "Personal preset"
                 },
                 {
                     "value": "legacy-preset",
@@ -45,10 +45,10 @@
             "visibilityCondition": false
         },
         {
-            "name": "tableau_server_secure_connection",
-            "label": "Tableau Server Secure Preset",
+            "name": "tableau_server_personal_connection",
+            "label": "Tableau Server Personal Preset",
             "type": "PRESET",
-            "parameterSetId": "secure-connection",
+            "parameterSetId": "tableau-personal-connection",
             "visibilityCondition": "model.auth_type == 'basic-oauth'"
         },
         {

--- a/python-lib/tableau_server_utils.py
+++ b/python-lib/tableau_server_utils.py
@@ -125,10 +125,10 @@ def get_tableau_server_connection(config):
     elif auth_type == "legacy-preset":
         configuration = config.get('tableau_server_connection', {})
     elif auth_type == "basic-oauth":
-        configuration = config.get('tableau_server_secure_connection', {})
-        tableau_secure_basic = configuration.get("tableau_secure_basic", {})
-        username = tableau_secure_basic.get("user")
-        password = tableau_secure_basic.get("password")
+        configuration = config.get('tableau_server_personal_connection', {})
+        tableau_personal_basic = configuration.get("tableau_personal_basic", {})
+        username = tableau_personal_basic.get("user")
+        password = tableau_personal_basic.get("password")
     else: # the auth_type selector was never used, so old conf file, use legacy mode
         server_url, username, password, site_id, ignore_ssl = get_legacy_tableau_server_connection(config)
         return server_url, username, password, site_id, ignore_ssl

--- a/python-lib/tableau_server_utils.py
+++ b/python-lib/tableau_server_utils.py
@@ -124,7 +124,7 @@ def get_tableau_server_connection(config):
         configuration = config
     elif auth_type == "legacy-preset":
         configuration = config.get('tableau_server_connection', {})
-    elif auth_type == "basic-oauth":
+    elif auth_type == "basic-preset":
         configuration = config.get('tableau_server_personal_connection', {})
         tableau_personal_basic = configuration.get("tableau_personal_basic", {})
         username = tableau_personal_basic.get("user")


### PR DESCRIPTION
Approach followed in this POC:

- Priority on keeping existing flows working
- Replace the 'Use preset' boolean with an auth method selector

Implementation details / consequences:

- The 'Use preset' boolean is hidden. It is still processed if present in the flow's json but cannot be add on new sync recipes.
- A new selector is added, with no default. If absent, the old way of selecting the active preset is used (using the Use preset info). If any auth method is selected, it takes absolute priority in the display of preset info.
- The preset displayed in the interface is only the one selected in the preset (nothing displayed if selector left untouched).
    - The behavior will look incoherent at first (recipe still working but presets invisible). The user will have to select a preset to see the one(s) already stored in the recipe, and is forced to make a choice. 
