### PR TITLE
[sc-187164] Fix: Invalid page number when querying tableau

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.5) - Feature release - 2024-06-04
 
-- Fix: Invalid page number when querying Tableau server
+- Fix: Correctly compute the total number of pages needed to query projects from a Tableau server to avoid invalid page number errors
 
 ## [Version 0.2.4](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.4) - Feature release - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.5) - Feature release - 2024-06-04
+
+- Fix: Invalid page number when querying Tableau server
+
 ## [Version 0.2.4](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.4) - Feature release - 2024-05-24
 
 - Chore: Removed usage of `.cache` directory, letting `tempfile` handle the location of the temporary file

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "tableau-hyper-export",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "meta": {
         "label": "Tableau Hyper format",
         "description": "Export datasets to Tableau .hyper format.",

--- a/python-lib/tableau_server_utils.py
+++ b/python-lib/tableau_server_utils.py
@@ -19,9 +19,13 @@ def get_project_from_name(server, project_name):
     :return: couple (Boolean{target project exists on server}, project)
     """
     page_nb = 1
-
     all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
-    pages_in_total = (pag_it.total_available // pag_it.page_size) + 1
+
+    partial_page = 1 if pag_it.total_available % pag_it.page_size > 0 else 0
+    pages_in_total = (pag_it.total_available // pag_it.page_size) + partial_page
+    logger.info(
+        f"Searching for project {project_name} in {pag_it.total_available} projects, querying {pages_in_total} pages ({partial_page} partial page) with page size: {pag_it.page_size}"
+    )
 
     while page_nb <= pages_in_total:
         all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
@@ -46,7 +50,13 @@ def get_full_list_of_projects(server):
     """
     page_nb = 1
     all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
-    pages_in_total = (pag_it.total_available // pag_it.page_size) + 1
+
+    partial_page = 1 if pag_it.total_available % pag_it.page_size > 0 else 0
+    pages_in_total = (pag_it.total_available // pag_it.page_size) + partial_page
+    logger.info(
+        f"Getting full list of {pag_it.total_available} projects, querying {pages_in_total} pages ({partial_page} partial page) with page size: {pag_it.page_size}"
+    )
+    
     all_projects = set()
 
     while page_nb <= pages_in_total:
@@ -62,9 +72,18 @@ def get_full_list_of_projects(server):
 
 
 def get_dict_of_projects_paths(server):
+    """
+    Computes a dictionary of all the available projects from a Tableau server 
+    """
     page_nb = 1
     all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
-    pages_in_total = (pag_it.total_available // pag_it.page_size) + 1
+
+    partial_page = 1 if pag_it.total_available % pag_it.page_size > 0 else 0
+    pages_in_total = (pag_it.total_available // pag_it.page_size) + partial_page
+    logger.info(
+        f"Getting dict of {pag_it.total_available} projects, querying {pages_in_total} pages ({partial_page} partial page) with page size: {pag_it.page_size}"
+    )
+    
     all_projects = {}
 
     while page_nb <= pages_in_total:

--- a/python-lib/tableau_server_utils.py
+++ b/python-lib/tableau_server_utils.py
@@ -18,17 +18,13 @@ def get_project_from_name(server, project_name):
     :param project_name: target project name
     :return: couple (Boolean{target project exists on server}, project)
     """
-    page_nb = 1
-    all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
+    logger.info(f"Searching for project {project_name}")
+    pages_in_total = compute_total_pages_for_projects(server)
 
-    partial_page = 1 if pag_it.total_available % pag_it.page_size > 0 else 0
-    pages_in_total = (pag_it.total_available // pag_it.page_size) + partial_page
-    logger.info(
-        f"Searching for project {project_name} in {pag_it.total_available} projects, querying {pages_in_total} pages ({partial_page} partial page) with page size: {pag_it.page_size}"
-    )
+    page_nb = 1
 
     while page_nb <= pages_in_total:
-        all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
+        all_project_items, _pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
         filtered_projects = list(
             filter(lambda x: x.name.encode('utf-8') == project_name, all_project_items)
         )
@@ -48,20 +44,14 @@ def get_full_list_of_projects(server):
     :param server:
     :return:
     """
-    page_nb = 1
-    all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
-
-    partial_page = 1 if pag_it.total_available % pag_it.page_size > 0 else 0
-    pages_in_total = (pag_it.total_available // pag_it.page_size) + partial_page
-    logger.info(
-        f"Getting full list of {pag_it.total_available} projects, querying {pages_in_total} pages ({partial_page} partial page) with page size: {pag_it.page_size}"
-    )
+    pages_in_total = compute_total_pages_for_projects(server)
     
     all_projects = set()
+    page_nb = 1
 
     while page_nb <= pages_in_total:
 
-        all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
+        all_project_items, _pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
         project_names = [x.name.encode('utf-8') for x in all_project_items]
         for name in project_names:
             all_projects.add(name)
@@ -75,20 +65,14 @@ def get_dict_of_projects_paths(server):
     """
     Computes a dictionary of all the available projects from a Tableau server 
     """
-    page_nb = 1
-    all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
-
-    partial_page = 1 if pag_it.total_available % pag_it.page_size > 0 else 0
-    pages_in_total = (pag_it.total_available // pag_it.page_size) + partial_page
-    logger.info(
-        f"Getting dict of {pag_it.total_available} projects, querying {pages_in_total} pages ({partial_page} partial page) with page size: {pag_it.page_size}"
-    )
+    pages_in_total = compute_total_pages_for_projects(server)
     
     all_projects = {}
+    page_nb = 1
 
     while page_nb <= pages_in_total:
 
-        all_project_items, pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
+        all_project_items, _pag_it = server.projects.get(req_options=tsc.RequestOptions(pagenumber=page_nb))
         for all_project_item in all_project_items:
             all_projects[all_project_item.id] = {"name": all_project_item.name, "parent": all_project_item.parent_id}
         page_nb += 1
@@ -178,3 +162,24 @@ def setup_ssl(ignore_ssl, ssl_cert_path):
             # default variables handled by python requests to validate cert (used by underlying tableauserverclient)
             os.environ['REQUESTS_CA_BUNDLE'] = ssl_cert_path
             os.environ['CURL_CA_BUNDLE'] = ssl_cert_path
+
+
+def compute_total_pages_for_projects(server) -> int:
+    """
+    Computes the number of pages necessary to query all the projects available on a Tableau server
+
+    :param server: tableau server
+    :return: Total number of pages
+    """
+    _project_items, pag_it = server.projects.get(
+        req_options=tsc.RequestOptions(pagenumber=1)
+    )
+
+    partial_page = 1 if pag_it.total_available % pag_it.page_size > 0 else 0
+    pages_in_total = (pag_it.total_available // pag_it.page_size) + partial_page
+
+    logger.info(
+        f"{pag_it.total_available} projects, divided in {pages_in_total} pages ({partial_page} partial page) with a page size of {pag_it.page_size}"
+    )
+
+    return pages_in_total


### PR DESCRIPTION
Card: [187164](https://app.shortcut.com/dataiku/story/187164/fix-invalid-page-number-when-querying-tableau-server)

## Issues

The total number of pages to query was incorrectly computed, adding one more page to query (it was done to take into account the last "partial" page with less than page_size projects) even when the number of projects was a multiple of the page size.
In this particular case, it created issues when:
- Attempting to target a project that was not existing, which lead to query the last (not existing) page
- Raising an error in the plugin exporter settings, when checking `Select project from list`. The error raised was caught and a `Check the authentication details` message was displayed.

## Fix

- Only add a (partial) page to the total number of pages when the number of available projects is **not a multiple of the page size**
- Some logs