### PR TITLE
Bug/dss13 sc 219621 table missing in hyper file produced when a lot of columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Bugfix release - 2024-12-17
 
-- Fix: For datasets with large numbers of columns (approximately 150 and over) and over (approximately) 90,000 rows the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files. This was due to a wrongly ordered close statements.
+- Fix: For datasets with large numbers of columns rows the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files.
 
 ## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.5) - Feature release - 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
-## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Feature release - 2024-12-06
+## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Feature release - 2024-12-06
 
-- Fix: For datasets with large numbers of columns and over 90,000 rows the export/upload hyper file did not contain the table 
+- Fix: Datasets with large numbers of columns and over 90,000 rows the export/upload hyper file did not contain the table exported.
 
 ## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.5) - Feature release - 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Feature release - 2024-12-17
+## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Bugfix release - 2024-12-17
 
 - Fix: For datasets with large numbers of columns (approximately 150 and over) and over (approximately) 90,000 rows the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files. This was due to a wrongly ordered close statements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Feature release - 2024-12-06
+## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Feature release - 2024-12-17
 
 - Fix: For datasets with large numbers of columns (approximately 150 and over) and over (approximately) 90,000 rows the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files. This was due to a wrongly ordered close statements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Bugfix release - 2024-12-17
 
-- Fix: For datasets with large numbers of columns the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files.
+- Fix: For datasets with large numbers of columns and rows the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files.
 
 ## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.5) - Feature release - 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Feature release - 2024-12-06
+
+- Fix: For datasets with large numbers of columns and over 90,000 rows the export/upload hyper file did not contain the table 
 
 ## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.5) - Feature release - 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Bugfix release - 2024-12-17
 
-- Fix: For datasets with large numbers of columns rows the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files.
+- Fix: For datasets with large numbers of columns the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files.
 
 ## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.5) - Feature release - 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [Version 0.2.6](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.6) - Feature release - 2024-12-06
 
-- Fix: Datasets with large numbers of columns and over 90,000 rows the export/upload hyper file did not contain the table exported.
+- Fix: For datasets with large numbers of columns (approximately 150 and over) and over (approximately) 90,000 rows the export/upload hyper file did not contain the table exported. This led to the failure of uploads to Tableau and the export of unusable hyper files. This was due to a wrongly ordered close statements.
 
 ## [Version 0.2.5](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v0.2.5) - Feature release - 2024-06-04
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "tableau-hyper-export",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "meta": {
         "label": "Tableau Hyper format",
         "description": "Export datasets to Tableau .hyper format.",

--- a/python-lib/tableau_table_writer.py
+++ b/python-lib/tableau_table_writer.py
@@ -168,7 +168,7 @@ class TableauTableWriter(object):
             logger.warning("Failed to perform writing on the last rows")
             raise err
         finally:
-            self.hyper.close()
             self.connection.close()
+            self.hyper.close()
             logger.info("Closed export")
         return True


### PR DESCRIPTION
Appears to have just been the result of `hyper` being closed before `connection`