### PR TITLE
[sc-305651] Fix: Java Hyper Export - Cannot read field "columnFactory" because "ssc" is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v1.0.1) - Bugfix release - 2026-03
 
-- Fixed a race condition in TableauExporter where column resolution happened before the input thread had registered columns in the shared ColumnFactory
+- Fixed a race condition in the Java Tableau exporter that caused export jobs to fail randomly on slow data sources.
 
 ## [Version 1.0.0](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v1.0.0) - Feature release - 2025-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.1](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v1.0.1) - Bugfix release - 2026-03
+
+- Fixed a race condition in TableauExporter where column resolution happened before the input thread had registered columns in the shared ColumnFactory
+
 ## [Version 1.0.0](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v1.0.0) - Feature release - 2025-08
 
 - New exporter working only on linux to speed up export time

--- a/java-src/com/dataiku/dss/export/tableau/TableauExporter.java
+++ b/java-src/com/dataiku/dss/export/tableau/TableauExporter.java
@@ -182,8 +182,9 @@ public class TableauExporter implements CustomExporter  {
     public void stream(RowInputStream stream) throws Exception {
         this.columns = new ArrayList<>();
         this.types = new ArrayList<>();
+        // Ensures schema columns exist in the shared ColumnFactory before streaming rows.
         for (SchemaColumn sc : this.schema.getColumns()) {
-            this.columns.add(this.cf.getColumn(sc.getName()));
+            this.columns.add(this.cf.column(sc.getName()));
             this.types.add(sc.getType());
         }
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "tableau-hyper-export",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "meta": {
         "label": "Tableau Hyper format",
         "description": "Export datasets to Tableau .hyper format. ⚠️ Starting from 1.0.0, DSS geometry columns are now exported as Geography.",


### PR DESCRIPTION
## Overview

Card: [sc-305651](https://app.shortcut.com/dataiku/story/305651)

Issue: Fixed a race condition in `TableauExporter` caused by resolving schema columns from the shared `ColumnFactory` with `cf.getColumn()` before they had been created.

The input and output threads of the export pipeline share a single `StreamColumnFactory`. In the Java exporter, column handles were resolved from the schema using `cf.getColumn(sc.getName())`, which can return `null` if the column is not yet registered in the shared factory. This could later cause export failures.

Solution: Resolved schema columns with `cf.column(sc.getName())` instead of `cf.getColumn(sc.getName())`.

This ensures schema columns exist in the shared `ColumnFactory` before streaming rows, while still reusing the same shared column handles across the export pipeline.

## Demo

Before:

<img width="1509" height="860" alt="Screenshot 2026-03-13 at 15 03 44" src="https://github.com/user-attachments/assets/728c8faf-ca74-4734-847f-a7dd4d18a774" />

After:

<img width="1511" height="859" alt="Screenshot 2026-03-13 at 15 38 51" src="https://github.com/user-attachments/assets/57a4f7ee-47c3-4d9c-917e-0e3d8d3e0170" />

Note: to trigger the error, you can just do an `Export to file`, no need for an actual export to Tableau. Exporting to Tableau still lets you verify that the generated Hyper table is correct.
