### PR TITLE
Chore: merge master-pre14.4 to master - [sc-305651] Fix: Java Hyper Export - Cannot read field "columnFactory" because "ssc" is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.1](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v1.0.1) - Bugfix release - 2026-03
+
+- Fixed a race condition in the Java Tableau exporter that caused export jobs to fail randomly on slow data sources.
+
 ## [Version 1.0.0](https://github.com/dataiku/dss-plugin-tableau-hyper/releases/tag/v1.0.0) - Feature release - 2025-08
 
 - New exporter working only on linux to speed up export time

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := plugin
+
 # Makefile variables set automatically
 plugin_id=`cat plugin.json | python3 -c "import sys, json; print(str(json.load(sys.stdin)['id']).replace('/',''))"`
 plugin_version=`cat plugin.json | python3 -c "import sys, json; print(str(json.load(sys.stdin)['version']).replace('/',''))"`

--- a/java-src/com/dataiku/dss/export/tableau/TableauExporter.java
+++ b/java-src/com/dataiku/dss/export/tableau/TableauExporter.java
@@ -182,8 +182,9 @@ public class TableauExporter implements CustomExporter  {
     public void stream(RowInputStream stream) throws Exception {
         this.columns = new ArrayList<>();
         this.types = new ArrayList<>();
+        // Ensures schema columns exist in the shared ColumnFactory before streaming rows.
         for (SchemaColumn sc : this.schema.getColumns()) {
-            this.columns.add(this.cf.getColumn(sc.getName()));
+            this.columns.add(this.cf.column(sc.getName()));
             this.types.add(sc.getType());
         }
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "tableau-hyper-export",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "meta": {
         "label": "Tableau Hyper format",
         "description": "Export datasets to Tableau .hyper format. ⚠️ Starting from 1.0.0, DSS geometry columns are now exported as Geography.",


### PR DESCRIPTION
## Overview

Merge branch `master-pre14.4` to propagate fix from [sc-305651](https://app.shortcut.com/dataiku/story/305651/tableau-hyper-fix-java-hyper-export-cannot-read-field-columnfactory-because-ssc-is-null)
Fix from this PR: https://github.com/dataiku/dss-plugin-tableau-hyper/pull/38

Bump to version `1.1.1`

Note ⚠️: should be merged targeting a 14.4+ devenv
